### PR TITLE
feat(view) Select Pageの実装

### DIFF
--- a/src/api/puzzleAPI.ts
+++ b/src/api/puzzleAPI.ts
@@ -1,0 +1,12 @@
+import Axios from "axios";
+import Puzzle from "@/models/Puzzle";
+
+Axios.defaults.baseURL = "http://localhost:5000";
+
+export async function getPuzzle(): Promise<Puzzle[]> {
+  const response = await Axios.get("/select");
+  if (response) {
+    return response.data;
+  }
+  return [] as Puzzle[];
+}

--- a/src/components/PCard.vue
+++ b/src/components/PCard.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="card" :style="{ 'background-color': color }">
     <p class="card-label">{{ cardLabel }}</p>
-    <img :src="url" alt="alt" />
+    <img :src="src" alt="alt" />
     <p-button :text="label" :click="click"></p-button>
   </div>
 </template>
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from "vue-property-decorator";
+import { Vue, Component, Prop, Emit, Watch } from "vue-property-decorator";
 import PButton from "@/components/PButton.vue";
 
 @Component({
@@ -15,9 +15,9 @@ import PButton from "@/components/PButton.vue";
   },
 })
 export default class PCard extends Vue {
-  get url() {
-    return require("../assets/logo.png");
-  }
+  @Prop({ default: "" })
+  src?: string;
+
   @Prop()
   cardLabel?: string;
 
@@ -54,5 +54,6 @@ img {
   width: 80%;
   height: 150px;
   border-radius: 3px;
+  margin-bottom: 10px;
 }
 </style>

--- a/src/components/PCard.vue
+++ b/src/components/PCard.vue
@@ -15,7 +15,6 @@ import PButton from "@/components/PButton.vue";
   },
 })
 export default class PCard extends Vue {
-  @Prop({ default: "" })
   get url() {
     return require("../assets/logo.png");
   }
@@ -40,7 +39,7 @@ export default class PCard extends Vue {
 <style>
 .card {
   width: 300px;
-  height: 400px;
+  height: 300px;
   margin: 10px;
   background-color: rgb(55, 134, 204);
   border: solid 2px rgb(36, 41, 46);
@@ -53,7 +52,7 @@ export default class PCard extends Vue {
 
 img {
   width: 80%;
-  height: 50%;
+  height: 150px;
   border-radius: 3px;
 }
 </style>

--- a/src/components/PCard.vue
+++ b/src/components/PCard.vue
@@ -2,7 +2,7 @@
   <div class="card" :style="{ 'background-color': color }">
     <p class="card-label">{{ cardLabel }}</p>
     <img :src="src" alt="alt" />
-    <p-button :text="label" :click="click"></p-button>
+    <p-button :text="label" @push="play"></p-button>
   </div>
 </template>
 <script lang="ts">
@@ -15,6 +15,9 @@ import PButton from "@/components/PButton.vue";
   },
 })
 export default class PCard extends Vue {
+  @Prop()
+  id?: string;
+
   @Prop({ default: "" })
   src?: string;
 
@@ -30,9 +33,9 @@ export default class PCard extends Vue {
   @Prop({ default: "bisque" })
   color?: string;
 
-  @Emit("click")
-  click(value: any) {
-    return value;
+  @Emit("play")
+  play() {
+    return this.id;
   }
 }
 </script>

--- a/src/models/Puzzle.ts
+++ b/src/models/Puzzle.ts
@@ -1,0 +1,7 @@
+export default interface Puzzle {
+  user_id: string;
+  name: string;
+  ref: string;
+  size: number;
+  url: string;
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import VueRouter, { RouteConfig } from "vue-router";
 import Home from "../views/Home.vue";
 import Index from "@/views/Index.vue";
 import LoginPage from "@/views/LoginPage.vue";
+import SelectPage from "@/views/SelectPage.vue";
 
 Vue.use(VueRouter);
 
@@ -25,6 +26,11 @@ const routes: Array<RouteConfig> = [
     path: "/login",
     name: "Login",
     component: LoginPage,
+  },
+  {
+    path: "/select",
+    name: "Select",
+    component: SelectPage,
   },
 ];
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,6 +32,11 @@ const routes: Array<RouteConfig> = [
     name: "Select",
     component: SelectPage,
   },
+  {
+    path: "/play/:id",
+    name: "play",
+    component: Index,
+  },
 ];
 
 const router = new VueRouter({

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -5,7 +5,9 @@
       <p>自分の好きな画像でパズルができるアプリです。</p>
       <div class="buttons">
         <p-button color="white" text="投稿する" />
-        <p-button color="white" text="遊ぶ" />
+        <router-link to="/select"
+          ><p-button color="white" text="遊ぶ"
+        /></router-link>
       </div>
     </div>
     <div>

--- a/src/views/SelectPage.vue
+++ b/src/views/SelectPage.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="puzzle-list">
+    <template v-for="item in items">
+      <p-card
+        :key="item.key"
+        :cardLabel="item.cardLabel"
+        :label="item.label"
+      ></p-card>
+    </template>
+  </div>
+</template>
+<script>
+import { Vue, Component } from "vue-property-decorator";
+import PCard from "@/components/PCard.vue";
+
+@Component({
+  components: {
+    PCard,
+  },
+})
+export default class SelectPage extends Vue {
+  items = [
+    {
+      key: 1,
+      cardLabel: "testCardLabel",
+      label: "test",
+    },
+    {
+      key: 2,
+      cardLabel: "testCardLabel",
+      label: "test",
+    },
+    {
+      key: 3,
+      cardLabel: "testCardLabel",
+      label: "test",
+    },
+    {
+      key: 4,
+      cardLabel: "testCardLabel",
+      label: "test",
+    },
+  ];
+}
+</script>
+<style>
+.puzzle-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/views/SelectPage.vue
+++ b/src/views/SelectPage.vue
@@ -3,15 +3,18 @@
     <template v-for="item in items">
       <p-card
         :key="item.key"
-        :cardLabel="item.cardLabel"
-        :label="item.label"
+        :cardLabel="item.name"
+        :src="item.url"
+        label="遊ぶ"
       ></p-card>
     </template>
   </div>
 </template>
-<script>
+<script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import PCard from "@/components/PCard.vue";
+import Puzzle from "@/models/Puzzle";
+import { getPuzzle } from "@/api/puzzleAPI";
 
 @Component({
   components: {
@@ -19,28 +22,12 @@ import PCard from "@/components/PCard.vue";
   },
 })
 export default class SelectPage extends Vue {
-  items = [
-    {
-      key: 1,
-      cardLabel: "testCardLabel",
-      label: "test",
-    },
-    {
-      key: 2,
-      cardLabel: "testCardLabel",
-      label: "test",
-    },
-    {
-      key: 3,
-      cardLabel: "testCardLabel",
-      label: "test",
-    },
-    {
-      key: 4,
-      cardLabel: "testCardLabel",
-      label: "test",
-    },
-  ];
+  public items?: Puzzle[] = [];
+
+  async created() {
+    this.items = await getPuzzle();
+    console.log(this.items);
+  }
 }
 </script>
 <style>

--- a/src/views/SelectPage.vue
+++ b/src/views/SelectPage.vue
@@ -3,8 +3,10 @@
     <template v-for="item in items">
       <p-card
         :key="item.key"
+        :id="item.id"
         :cardLabel="item.name"
         :src="item.url"
+        @play="moveToPlayPage"
         label="遊ぶ"
       ></p-card>
     </template>
@@ -27,6 +29,10 @@ export default class SelectPage extends Vue {
   async created() {
     this.items = await getPuzzle();
     console.log(this.items);
+  }
+
+  moveToPlayPage(value: string) {
+    this.$router.push({ name: `play`, params: { id: value } });
   }
 }
 </script>


### PR DESCRIPTION
# Select Pageの実装

* SelectPageの実装
* リスト受信時のPuzzle型の実装
*  backend側からパズルデータを取得するAPI(getPuzzle）を実装
*  取得したデータのidをrouterに渡す

## 追加した型
Puzzle (@/models/Puzzle.ts)
|name|type|
|---|---|
|user_id| string  |
|name|string  |
|ref|string  |
|size|number|  
|url|string  |

## 追加したAPI

|メソッド名|URL|
|---|---|
|getPuzzle| "/select" : GET |

## ルーティング  
|path|Component|
|---|---|
|'/select'| SelectPage |

### コンポーネント
PCard @/components/PCard.vue
```
@Prop()
id : string
src: string
cardLabel:string
alt :string
label: string
color:string

```

SelectPage @/views/SelectPage.vue
```
public item: Puzzle[]
```


