### PR TITLE
fix(footer) ブラウザの最下部に常に配置するように修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,10 @@ export default class App extends Vue {}
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;
+  min-height: 100vh;
+  position: relative;
+  padding-bottom: 10%;
+  box-sizing: border-box;
 }
 
 #nav {

--- a/src/components/PFooter.vue
+++ b/src/components/PFooter.vue
@@ -21,5 +21,8 @@ footer {
   color: white;
   padding-bottom: 5px;
   text-align: center;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
 }
 </style>


### PR DESCRIPTION
# fix(footer) ブラウザの最下部に常に配置するように修正

|名前|イメージ|
|---|---|
|修正前|![Screenshot from 2021-02-16 02-33-52](https://user-images.githubusercontent.com/38244340/107978044-7aa66180-6fff-11eb-949b-cdbe68a7f0f1.png)|
|修正後|![Screenshot from 2021-02-16 02-34-56](https://user-images.githubusercontent.com/38244340/107978119-9b6eb700-6fff-11eb-860e-997a11b36026.png)|